### PR TITLE
Implement direction enum in t_ray_result

### DIFF
--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -69,12 +69,21 @@ typedef struct s_config {
 	int			height;
 }	t_config;
 
+typedef enum e_direction {
+        NORTH,
+        SOUTH,
+        EAST,
+        WEST
+}       t_direction;
+
 typedef struct s_ray_result
 {
-	double		distance;
-	int			texture_x;
-	mlx_texture_t *texture;
-}	t_ray_result;
+        double          distance;
+        int                     texture_x;
+        mlx_texture_t *texture;
+        t_direction     direction;
+}       t_ray_result;
+
 
 
 void	parse_cub_file(const char *path, t_config *cfg);


### PR DESCRIPTION
## Summary
- add `e_direction` enum for ray hits
- add `direction` field to `t_ray_result`

## Testing
- `make` *(fails: MLX42 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848c5852bdc8327bbd1b187a18ff10a