### PR TITLE
Add map cleanup helper

### DIFF
--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -103,6 +103,7 @@ void	validate_closed_map(char **map, int height, int width);
 // Utils
 uint32_t get_texture_pixel(mlx_texture_t *tex, int x, int y);
 void	free_config(t_config *cfg);
+void    free_map(char **map, int height);
 uint32_t parse_color(char *line);
 void free_split(char **split);
 void parse_texture_or_color(t_config *cfg, char *line);

--- a/src/parse_map.c
+++ b/src/parse_map.c
@@ -98,10 +98,16 @@ bool parse_cub_file(const char *path, t_config *cfg)
 	char **map;
 	int height;
 
-	map = read_cub_file(path, cfg, &height);
-	if (!map)
-		return (false);
-	if (!validate_and_prepare_map(map, height, cfg))
-		return (false);
-	return (true);
+    map = read_cub_file(path, cfg, &height);
+    if (!map)
+    {
+            free_map(map, height);
+            return (false);
+    }
+    if (!validate_and_prepare_map(map, height, cfg))
+    {
+            free_map(map, height);
+            return (false);
+    }
+    return (true);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -104,9 +104,21 @@ void set_player_direction(t_config *cfg, char dir)
 		cfg->player.dir_x = 1;
 		cfg->player.plane_y = 0.66;
 	}
-	else if (dir == 'W')
-	{
-		cfg->player.dir_x = -1;
-		cfg->player.plane_y = -0.66;
-	}
+        else if (dir == 'W')
+        {
+                cfg->player.dir_x = -1;
+                cfg->player.plane_y = -0.66;
+        }
+}
+
+void    free_map(char **map, int height)
+{
+        int i;
+
+        if (!map)
+                return ;
+        i = 0;
+        while (i < height && map[i])
+                free(map[i++]);
+        free(map);
 }

--- a/src/utils2.c
+++ b/src/utils2.c
@@ -37,6 +37,7 @@ char **read_cub_file(const char *path, t_config *cfg, int *out_height)
 	int		fd;
 	char	*line;
 	char	**map;
+        *out_height = 0;
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0)
@@ -47,12 +48,15 @@ char **read_cub_file(const char *path, t_config *cfg, int *out_height)
 	map = malloc(sizeof(char *) * (MAX_MAP_HEIGHT + 1));
 	if (!map)
 		return (close(fd), NULL);
-	*out_height = 0;
 	line = get_next_line(fd);
 	while (line && *out_height < MAX_MAP_HEIGHT)
 	{
-		if (!process_line(cfg, line, map, out_height, fd))
-			return (NULL);
+                if (!process_line(cfg, line, map, out_height, fd))
+                {
+                        free_map(map, *out_height);
+                        close(fd);
+                        return (NULL);
+                }
 		line = get_next_line(fd);
 	}
 	map[*out_height] = NULL;


### PR DESCRIPTION
## Summary
- add `free_map` helper for freeing partially loaded maps
- ensure parse_cub_file frees the map on failure
- update read_cub_file to clean up when a line fails
- expose helper in header

## Testing
- `make` *(fails: MLX42 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68509b7e98ec8327bb547e52a4350cc0